### PR TITLE
expose `BasicRetryPolicy` publicly so that it can be referenced in user code

### DIFF
--- a/sdk/messaging_eventhubs/src/core/basic_retry_policy.rs
+++ b/sdk/messaging_eventhubs/src/core/basic_retry_policy.rs
@@ -11,6 +11,7 @@ const DEFAULT_JITTER_FACTOR: f64 = 0.08;
 // const DEFAULT_MINIMUM_THROTTLE_SECONDS: u32 = 4;
 // const DEFAULT_MAXIMUM_THROTTLE_SECONDS: u32 = 8;
 
+/// Default retry policy used by the client.
 #[derive(Debug, Clone)]
 pub struct BasicRetryPolicy {
     options: EventHubsRetryOptions,

--- a/sdk/messaging_eventhubs/src/lib.rs
+++ b/sdk/messaging_eventhubs/src/lib.rs
@@ -152,6 +152,7 @@ cfg_not_wasm32! {
     pub mod primitives;
     pub mod producer;
 
+    pub use crate::core::BasicRetryPolicy;
     pub use crate::event_data::*;
     pub use crate::event_hubs_connection::*;
     pub use crate::event_hubs_connection_option::*;


### PR DESCRIPTION
Currently if trying to store `EventHubConsumerClient<...>` in a struct the type must be fully declared. (If there's a way around this please let me know)

It looks like the intention was for `BasicRetryPolicy` to be public, but since `core` was not public it didn't quite propagate out.

Please let me know if this change is helpful or aligns with your intentions. More than happy to make any changes desired here too.

Is this the right branch to merge into?