### PR TITLE
updated fe2o3-amqp-ws to 0.4.0

### DIFF
--- a/sdk/messaging_eventhubs/Cargo.toml
+++ b/sdk/messaging_eventhubs/Cargo.toml
@@ -43,7 +43,7 @@ fe2o3-amqp-types = "0.7.1"
 fe2o3-amqp-management = "0.2.2"
 fe2o3-amqp-cbs = "0.2"
 serde_amqp = { version = "0.5.9", features = ["derive", "time"] }
-fe2o3-amqp-ws = "0.3.1"
+fe2o3-amqp-ws = "0.4.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["rt", "macros", "sync", "time", "net"] }


### PR DESCRIPTION
This comes with an upstream fix of [CVE-2023-43669](https://github.com/snapview/tungstenite-rs/pull/379).